### PR TITLE
Adding missing migration for optional repo name

### DIFF
--- a/api/db/migrations/20220127061055_optional_repo_name/migration.sql
+++ b/api/db/migrations/20220127061055_optional_repo_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Repository" ALTER COLUMN "name" DROP NOT NULL;


### PR DESCRIPTION
Not having all schema changes committed as migrations makes it a little bit more difficult to get started with the project as the first thing you have to do when running `yarn rw prisma migrate dev` to get your local db to a state that will work with the project is to name the missing migration. And since you're just getting started you probably don't even know what the migration is about, let alone what to name it.